### PR TITLE
refactor: 응답 객체의 작명 규칙 변경

### DIFF
--- a/src/main/java/ex/sample/domain/sample/controller/SampleController.java
+++ b/src/main/java/ex/sample/domain/sample/controller/SampleController.java
@@ -1,8 +1,8 @@
 package ex.sample.domain.sample.controller;
 
-import ex.sample.domain.sample.dto.request.CreateSampleReq;
-import ex.sample.domain.sample.dto.response.CreateSampleRes;
-import ex.sample.domain.sample.dto.response.GetSampleRes;
+import ex.sample.domain.sample.dto.request.CreateSampleRequest;
+import ex.sample.domain.sample.dto.response.CreateSampleResponse;
+import ex.sample.domain.sample.dto.response.GetSampleResponse;
 import ex.sample.domain.sample.service.SampleCommandService;
 import ex.sample.domain.sample.service.SampleQueryService;
 import ex.sample.global.response.ApiResponse;
@@ -33,8 +33,8 @@ public class SampleController {
      * 샘플 단건 조회
      */
     @GetMapping("/{id}")
-    public ApiResponse<GetSampleRes> getSample(@PathVariable("id") Long id) {
-        GetSampleRes response = sampleQueryService.getSample(id);
+    public ApiResponse<GetSampleResponse> getSample(@PathVariable("id") Long id) {
+        GetSampleResponse response = sampleQueryService.getSample(id);
         return ApiResponse.success(response);
     }
 
@@ -42,10 +42,10 @@ public class SampleController {
      * 샘플 리스트 조회
      */
     @GetMapping
-    public ApiResponse<PageResponse<GetSampleRes>> getSample(
+    public ApiResponse<PageResponse<GetSampleResponse>> getSample(
         @PageableDefault(size = 20, sort = "createdAt", direction = Direction.DESC) Pageable pageable
     ) {
-        PageResponse<GetSampleRes> response = sampleQueryService.getSampleList(pageable);
+        PageResponse<GetSampleResponse> response = sampleQueryService.getSampleList(pageable);
         return ApiResponse.success(response);
     }
 
@@ -53,8 +53,8 @@ public class SampleController {
      * 샘플 생성
      */
     @PostMapping
-    public ApiResponse<CreateSampleRes> createSample(@Validated @RequestBody CreateSampleReq request) {
-        CreateSampleRes response = sampleCommandService.createSample(request);
+    public ApiResponse<CreateSampleResponse> createSample(@Validated @RequestBody CreateSampleRequest request) {
+        CreateSampleResponse response = sampleCommandService.createSample(request);
         return ApiResponse.success(response);
     }
 }

--- a/src/main/java/ex/sample/domain/sample/controller/SampleController.java
+++ b/src/main/java/ex/sample/domain/sample/controller/SampleController.java
@@ -6,7 +6,7 @@ import ex.sample.domain.sample.dto.response.GetSampleRes;
 import ex.sample.domain.sample.service.SampleCommandService;
 import ex.sample.domain.sample.service.SampleQueryService;
 import ex.sample.global.response.ApiResponse;
-import ex.sample.global.response.CommonPageRes;
+import ex.sample.global.response.PageResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -42,10 +42,10 @@ public class SampleController {
      * 샘플 리스트 조회
      */
     @GetMapping
-    public ApiResponse<CommonPageRes<GetSampleRes>> getSample(
+    public ApiResponse<PageResponse<GetSampleRes>> getSample(
         @PageableDefault(size = 20, sort = "createdAt", direction = Direction.DESC) Pageable pageable
     ) {
-        CommonPageRes<GetSampleRes> response = sampleQueryService.getSampleList(pageable);
+        PageResponse<GetSampleRes> response = sampleQueryService.getSampleList(pageable);
         return ApiResponse.success(response);
     }
 

--- a/src/main/java/ex/sample/domain/sample/controller/SampleController.java
+++ b/src/main/java/ex/sample/domain/sample/controller/SampleController.java
@@ -5,8 +5,8 @@ import ex.sample.domain.sample.dto.response.CreateSampleRes;
 import ex.sample.domain.sample.dto.response.GetSampleRes;
 import ex.sample.domain.sample.service.SampleCommandService;
 import ex.sample.domain.sample.service.SampleQueryService;
+import ex.sample.global.response.ApiResponse;
 import ex.sample.global.response.CommonPageRes;
-import ex.sample.global.response.CommonRes;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -33,28 +33,28 @@ public class SampleController {
      * 샘플 단건 조회
      */
     @GetMapping("/{id}")
-    public CommonRes<GetSampleRes> getSample(@PathVariable("id") Long id) {
+    public ApiResponse<GetSampleRes> getSample(@PathVariable("id") Long id) {
         GetSampleRes response = sampleQueryService.getSample(id);
-        return CommonRes.success(response);
+        return ApiResponse.success(response);
     }
 
     /**
      * 샘플 리스트 조회
      */
     @GetMapping
-    public CommonRes<CommonPageRes<GetSampleRes>> getSample(
+    public ApiResponse<CommonPageRes<GetSampleRes>> getSample(
         @PageableDefault(size = 20, sort = "createdAt", direction = Direction.DESC) Pageable pageable
     ) {
         CommonPageRes<GetSampleRes> response = sampleQueryService.getSampleList(pageable);
-        return CommonRes.success(response);
+        return ApiResponse.success(response);
     }
 
     /**
      * 샘플 생성
      */
     @PostMapping
-    public CommonRes<CreateSampleRes> createSample(@Validated @RequestBody CreateSampleReq request) {
+    public ApiResponse<CreateSampleRes> createSample(@Validated @RequestBody CreateSampleReq request) {
         CreateSampleRes response = sampleCommandService.createSample(request);
-        return CommonRes.success(response);
+        return ApiResponse.success(response);
     }
 }

--- a/src/main/java/ex/sample/domain/sample/dto/request/CreateSampleRequest.java
+++ b/src/main/java/ex/sample/domain/sample/dto/request/CreateSampleRequest.java
@@ -3,7 +3,7 @@ package ex.sample.domain.sample.dto.request;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
-public record CreateSampleReq(
+public record CreateSampleRequest(
 
     @Pattern(regexp = "^[a-zA-Z가-힣0-9]{1,20}$", message = "이름은 한글, 영문, 숫자만 20자 이내로 입력 가능합니다.")
     String name,

--- a/src/main/java/ex/sample/domain/sample/dto/response/CreateSampleResponse.java
+++ b/src/main/java/ex/sample/domain/sample/dto/response/CreateSampleResponse.java
@@ -1,6 +1,6 @@
 package ex.sample.domain.sample.dto.response;
 
-public record CreateSampleRes(
+public record CreateSampleResponse(
     Long id,
     String name,
     Long money

--- a/src/main/java/ex/sample/domain/sample/dto/response/GetSampleResponse.java
+++ b/src/main/java/ex/sample/domain/sample/dto/response/GetSampleResponse.java
@@ -1,6 +1,6 @@
 package ex.sample.domain.sample.dto.response;
 
-public record GetSampleRes(
+public record GetSampleResponse(
     Long id,
     String name,
     Long money

--- a/src/main/java/ex/sample/domain/sample/mapper/SampleMapper.java
+++ b/src/main/java/ex/sample/domain/sample/mapper/SampleMapper.java
@@ -1,8 +1,8 @@
 package ex.sample.domain.sample.mapper;
 
 import ex.sample.domain.sample.domain.Sample;
-import ex.sample.domain.sample.dto.response.CreateSampleRes;
-import ex.sample.domain.sample.dto.response.GetSampleRes;
+import ex.sample.domain.sample.dto.response.CreateSampleResponse;
+import ex.sample.domain.sample.dto.response.GetSampleResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants.ComponentModel;
@@ -11,8 +11,8 @@ import org.mapstruct.MappingConstants.ComponentModel;
 public interface SampleMapper {
 
     @Mapping(target = "money", source = "money.amount")
-    GetSampleRes toGetSampleRes(Sample sample);
+    GetSampleResponse toGetSampleRes(Sample sample);
 
     @Mapping(target = "money", source = "money.amount")
-    CreateSampleRes toCreateSampleRes(Sample sample);
+    CreateSampleResponse toCreateSampleRes(Sample sample);
 }

--- a/src/main/java/ex/sample/domain/sample/service/SampleCommandService.java
+++ b/src/main/java/ex/sample/domain/sample/service/SampleCommandService.java
@@ -1,8 +1,8 @@
 package ex.sample.domain.sample.service;
 
 import ex.sample.domain.sample.domain.Sample;
-import ex.sample.domain.sample.dto.request.CreateSampleReq;
-import ex.sample.domain.sample.dto.response.CreateSampleRes;
+import ex.sample.domain.sample.dto.request.CreateSampleRequest;
+import ex.sample.domain.sample.dto.response.CreateSampleResponse;
 import ex.sample.domain.sample.implementation.SampleSaver;
 import ex.sample.domain.sample.mapper.SampleMapper;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +22,7 @@ public class SampleCommandService {
      * 샘플 생성
      */
     @Transactional
-    public CreateSampleRes createSample(CreateSampleReq request) {
+    public CreateSampleResponse createSample(CreateSampleRequest request) {
         Sample sample = sampleSaver.create(request.name(), request.money());
         return sampleMapper.toCreateSampleRes(sample);
     }

--- a/src/main/java/ex/sample/domain/sample/service/SampleQueryService.java
+++ b/src/main/java/ex/sample/domain/sample/service/SampleQueryService.java
@@ -1,7 +1,7 @@
 package ex.sample.domain.sample.service;
 
 import ex.sample.domain.sample.domain.Sample;
-import ex.sample.domain.sample.dto.response.GetSampleRes;
+import ex.sample.domain.sample.dto.response.GetSampleResponse;
 import ex.sample.domain.sample.implementation.SampleReader;
 import ex.sample.domain.sample.mapper.SampleMapper;
 import ex.sample.global.response.PageResponse;
@@ -24,7 +24,7 @@ public class SampleQueryService {
      * 샘플 단건 조회
      */
     @Transactional(readOnly = true)
-    public GetSampleRes getSample(Long id) {
+    public GetSampleResponse getSample(Long id) {
         Sample sample = sampleReader.read(id);
         return sampleMapper.toGetSampleRes(sample);
     }
@@ -33,8 +33,8 @@ public class SampleQueryService {
      * 샘플 리스트 조회
      */
     @Transactional(readOnly = true)
-    public PageResponse<GetSampleRes> getSampleList(Pageable pageable) {
-        Page<GetSampleRes> pages = sampleReader.readAll(pageable)
+    public PageResponse<GetSampleResponse> getSampleList(Pageable pageable) {
+        Page<GetSampleResponse> pages = sampleReader.readAll(pageable)
             .map(sampleMapper::toGetSampleRes);
 
         return PageResponse.from(pages);

--- a/src/main/java/ex/sample/domain/sample/service/SampleQueryService.java
+++ b/src/main/java/ex/sample/domain/sample/service/SampleQueryService.java
@@ -4,7 +4,7 @@ import ex.sample.domain.sample.domain.Sample;
 import ex.sample.domain.sample.dto.response.GetSampleRes;
 import ex.sample.domain.sample.implementation.SampleReader;
 import ex.sample.domain.sample.mapper.SampleMapper;
-import ex.sample.global.response.CommonPageRes;
+import ex.sample.global.response.PageResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -33,10 +33,10 @@ public class SampleQueryService {
      * 샘플 리스트 조회
      */
     @Transactional(readOnly = true)
-    public CommonPageRes<GetSampleRes> getSampleList(Pageable pageable) {
+    public PageResponse<GetSampleRes> getSampleList(Pageable pageable) {
         Page<GetSampleRes> pages = sampleReader.readAll(pageable)
             .map(sampleMapper::toGetSampleRes);
 
-        return CommonPageRes.from(pages);
+        return PageResponse.from(pages);
     }
 }

--- a/src/main/java/ex/sample/domain/user/controller/UserAuthController.java
+++ b/src/main/java/ex/sample/domain/user/controller/UserAuthController.java
@@ -4,7 +4,7 @@ import ex.sample.domain.user.dto.request.UserSignupReq;
 import ex.sample.domain.user.dto.request.UserWithdrawalReq;
 import ex.sample.domain.user.service.UserAuthService;
 import ex.sample.global.response.ApiResponse;
-import ex.sample.global.response.CommonEmptyRes;
+import ex.sample.global.response.EmptyResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,19 +25,19 @@ public class UserAuthController {
     private final UserAuthService userAuthService;
 
     @PostMapping("/signup")
-    public ApiResponse<CommonEmptyRes> signup(
+    public ApiResponse<EmptyResponse> signup(
         @Valid @RequestBody UserSignupReq request
     ) {
-        CommonEmptyRes response = userAuthService.signup(request);
+        EmptyResponse response = userAuthService.signup(request);
         return ApiResponse.success(response);
     }
 
     @DeleteMapping
-    public ApiResponse<CommonEmptyRes> delete(
+    public ApiResponse<EmptyResponse> delete(
         @AuthenticationPrincipal UserDetails userDetails,
         @Valid @RequestBody UserWithdrawalReq request
     ) {
-        CommonEmptyRes response = userAuthService.deleteUser(userDetails, request);
+        EmptyResponse response = userAuthService.deleteUser(userDetails, request);
         return ApiResponse.success(response);
     }
 }

--- a/src/main/java/ex/sample/domain/user/controller/UserAuthController.java
+++ b/src/main/java/ex/sample/domain/user/controller/UserAuthController.java
@@ -3,8 +3,8 @@ package ex.sample.domain.user.controller;
 import ex.sample.domain.user.dto.request.UserSignupReq;
 import ex.sample.domain.user.dto.request.UserWithdrawalReq;
 import ex.sample.domain.user.service.UserAuthService;
+import ex.sample.global.response.ApiResponse;
 import ex.sample.global.response.CommonEmptyRes;
-import ex.sample.global.response.CommonRes;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,19 +25,19 @@ public class UserAuthController {
     private final UserAuthService userAuthService;
 
     @PostMapping("/signup")
-    public CommonRes<CommonEmptyRes> signup(
+    public ApiResponse<CommonEmptyRes> signup(
         @Valid @RequestBody UserSignupReq request
     ) {
         CommonEmptyRes response = userAuthService.signup(request);
-        return CommonRes.success(response);
+        return ApiResponse.success(response);
     }
 
     @DeleteMapping
-    public CommonRes<CommonEmptyRes> delete(
+    public ApiResponse<CommonEmptyRes> delete(
         @AuthenticationPrincipal UserDetails userDetails,
         @Valid @RequestBody UserWithdrawalReq request
     ) {
         CommonEmptyRes response = userAuthService.deleteUser(userDetails, request);
-        return CommonRes.success(response);
+        return ApiResponse.success(response);
     }
 }

--- a/src/main/java/ex/sample/domain/user/controller/UserAuthController.java
+++ b/src/main/java/ex/sample/domain/user/controller/UserAuthController.java
@@ -1,7 +1,7 @@
 package ex.sample.domain.user.controller;
 
-import ex.sample.domain.user.dto.request.UserSignupReq;
-import ex.sample.domain.user.dto.request.UserWithdrawalReq;
+import ex.sample.domain.user.dto.request.UserSignupRequest;
+import ex.sample.domain.user.dto.request.UserWithdrawalRequest;
 import ex.sample.domain.user.service.UserAuthService;
 import ex.sample.global.response.ApiResponse;
 import ex.sample.global.response.EmptyResponse;
@@ -26,7 +26,7 @@ public class UserAuthController {
 
     @PostMapping("/signup")
     public ApiResponse<EmptyResponse> signup(
-        @Valid @RequestBody UserSignupReq request
+        @Valid @RequestBody UserSignupRequest request
     ) {
         EmptyResponse response = userAuthService.signup(request);
         return ApiResponse.success(response);
@@ -35,7 +35,7 @@ public class UserAuthController {
     @DeleteMapping
     public ApiResponse<EmptyResponse> delete(
         @AuthenticationPrincipal UserDetails userDetails,
-        @Valid @RequestBody UserWithdrawalReq request
+        @Valid @RequestBody UserWithdrawalRequest request
     ) {
         EmptyResponse response = userAuthService.deleteUser(userDetails, request);
         return ApiResponse.success(response);

--- a/src/main/java/ex/sample/domain/user/dto/request/UserSignupRequest.java
+++ b/src/main/java/ex/sample/domain/user/dto/request/UserSignupRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-public record UserSignupReq(
+public record UserSignupRequest(
     @Email(message = "이메일 형식이 올바르지 않습니다.")
     String email,
 

--- a/src/main/java/ex/sample/domain/user/dto/request/UserWithdrawalRequest.java
+++ b/src/main/java/ex/sample/domain/user/dto/request/UserWithdrawalRequest.java
@@ -3,7 +3,7 @@ package ex.sample.domain.user.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-public record UserWithdrawalReq(
+public record UserWithdrawalRequest(
     @NotBlank(message = "비밀번호는 공백이 될 수 없습니다.")
     @Size(min = 8, max = 60, message = "비밀번호의 글자수는 8자 이상 60자 이하입니다.")
     String password

--- a/src/main/java/ex/sample/domain/user/service/UserAuthService.java
+++ b/src/main/java/ex/sample/domain/user/service/UserAuthService.java
@@ -1,8 +1,8 @@
 package ex.sample.domain.user.service;
 
 import ex.sample.domain.user.domain.User;
-import ex.sample.domain.user.dto.request.UserSignupReq;
-import ex.sample.domain.user.dto.request.UserWithdrawalReq;
+import ex.sample.domain.user.dto.request.UserSignupRequest;
+import ex.sample.domain.user.dto.request.UserWithdrawalRequest;
 import ex.sample.domain.user.repository.UserRepository;
 import ex.sample.global.exception.GlobalException;
 import ex.sample.global.response.EmptyResponse;
@@ -23,7 +23,7 @@ public class UserAuthService {
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
-    public EmptyResponse signup(UserSignupReq request) {
+    public EmptyResponse signup(UserSignupRequest request) {
         // 닉네임이 존재하는지 검증
         validateNickname(request.nickname());
 
@@ -55,7 +55,7 @@ public class UserAuthService {
     }
 
     @Transactional
-    public EmptyResponse deleteUser(UserDetails userDetails, UserWithdrawalReq request) {
+    public EmptyResponse deleteUser(UserDetails userDetails, UserWithdrawalRequest request) {
         String email = userDetails.getUsername();
 
         User user = userRepository.findByEmail(email)

--- a/src/main/java/ex/sample/domain/user/service/UserAuthService.java
+++ b/src/main/java/ex/sample/domain/user/service/UserAuthService.java
@@ -5,7 +5,7 @@ import ex.sample.domain.user.dto.request.UserSignupReq;
 import ex.sample.domain.user.dto.request.UserWithdrawalReq;
 import ex.sample.domain.user.repository.UserRepository;
 import ex.sample.global.exception.GlobalException;
-import ex.sample.global.response.CommonEmptyRes;
+import ex.sample.global.response.EmptyResponse;
 import ex.sample.global.response.ResponseCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,7 +23,7 @@ public class UserAuthService {
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
-    public CommonEmptyRes signup(UserSignupReq request) {
+    public EmptyResponse signup(UserSignupReq request) {
         // 닉네임이 존재하는지 검증
         validateNickname(request.nickname());
 
@@ -35,7 +35,7 @@ public class UserAuthService {
 
         userRepository.save(user);
 
-        return new CommonEmptyRes();
+        return new EmptyResponse();
     }
 
     private void validateNickname(String nickname) {
@@ -55,7 +55,7 @@ public class UserAuthService {
     }
 
     @Transactional
-    public CommonEmptyRes deleteUser(UserDetails userDetails, UserWithdrawalReq request) {
+    public EmptyResponse deleteUser(UserDetails userDetails, UserWithdrawalReq request) {
         String email = userDetails.getUsername();
 
         User user = userRepository.findByEmail(email)
@@ -67,6 +67,6 @@ public class UserAuthService {
 
         userRepository.deleteByEmail(userDetails.getUsername());
 
-        return new CommonEmptyRes();
+        return new EmptyResponse();
     }
 }

--- a/src/main/java/ex/sample/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ex/sample/global/exception/GlobalExceptionHandler.java
@@ -1,7 +1,7 @@
 package ex.sample.global.exception;
 
 import ex.sample.global.response.ApiResponse;
-import ex.sample.global.response.CommonEmptyRes;
+import ex.sample.global.response.EmptyResponse;
 import ex.sample.global.response.InvalidInputRes;
 import ex.sample.global.response.ResponseCode;
 import jakarta.servlet.http.HttpServletResponse;
@@ -34,7 +34,7 @@ public class GlobalExceptionHandler {
      * Business 오류 발생에 대한 핸들러
      */
     @ExceptionHandler(GlobalException.class)
-    public ApiResponse<CommonEmptyRes> handleGlobalException(GlobalException e) {
+    public ApiResponse<EmptyResponse> handleGlobalException(GlobalException e) {
         response.setStatus(e.getResponseCode().getHttpStatus().value()); // HttpStatus 설정
 
         return ApiResponse.error(e.getResponseCode()); // 공통 응답 양식 반환
@@ -52,7 +52,7 @@ public class GlobalExceptionHandler {
         MissingPathVariableException.class,
         MissingServletRequestParameterException.class
     })
-    public ApiResponse<CommonEmptyRes> handleGlobalException(Exception e) {
+    public ApiResponse<EmptyResponse> handleGlobalException(Exception e) {
         response.setStatus(ResponseCode.INVALID_INPUT.getHttpStatus().value()); // HttpStatus 설정
 
         return ApiResponse.error(ResponseCode.INVALID_INPUT); // 공통 응답 양식 반환
@@ -83,7 +83,7 @@ public class GlobalExceptionHandler {
      * 예상치 못한 에러 발생에 대한 핸들러
      */
     @ExceptionHandler({Exception.class, RuntimeException.class})
-    public ApiResponse<CommonEmptyRes> handleException(Exception e) {
+    public ApiResponse<EmptyResponse> handleException(Exception e) {
         log.error("예상치 못한 에러 발생", e);
         response.setStatus(ResponseCode.SYSTEM_ERROR.getHttpStatus().value()); // HttpStatus 설정
 

--- a/src/main/java/ex/sample/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ex/sample/global/exception/GlobalExceptionHandler.java
@@ -2,7 +2,7 @@ package ex.sample.global.exception;
 
 import ex.sample.global.response.ApiResponse;
 import ex.sample.global.response.EmptyResponse;
-import ex.sample.global.response.InvalidInputRes;
+import ex.sample.global.response.InvalidInputResponse;
 import ex.sample.global.response.ResponseCode;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
@@ -62,16 +62,16 @@ public class GlobalExceptionHandler {
      * Validation 라이브러리로 RequestBody 입력 파라미터 검증 오류 발생에 대한 핸들러
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ApiResponse<List<InvalidInputRes>> handlerValidationException(MethodArgumentNotValidException e) {
+    public ApiResponse<List<InvalidInputResponse>> handlerValidationException(MethodArgumentNotValidException e) {
         response.setStatus(ResponseCode.INVALID_INPUT.getHttpStatus().value()); // HttpStatus 설정
 
         // 잘못된 입력 에러들을 DTO 변환
-        List<InvalidInputRes> invalidInputResList = changeFieldErrorToDto(e);
+        List<InvalidInputResponse> invalidInputResponseList = changeFieldErrorToDto(e);
 
-        return ApiResponse.error(ResponseCode.INVALID_INPUT, invalidInputResList); // 공통 응답 양식 반환
+        return ApiResponse.error(ResponseCode.INVALID_INPUT, invalidInputResponseList); // 공통 응답 양식 반환
     }
 
-    private List<InvalidInputRes> changeFieldErrorToDto(MethodArgumentNotValidException e) {
+    private List<InvalidInputResponse> changeFieldErrorToDto(MethodArgumentNotValidException e) {
         return e.getBindingResult()
             .getFieldErrors()
             .stream()

--- a/src/main/java/ex/sample/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ex/sample/global/exception/GlobalExceptionHandler.java
@@ -1,7 +1,7 @@
 package ex.sample.global.exception;
 
+import ex.sample.global.response.ApiResponse;
 import ex.sample.global.response.CommonEmptyRes;
-import ex.sample.global.response.CommonRes;
 import ex.sample.global.response.InvalidInputRes;
 import ex.sample.global.response.ResponseCode;
 import jakarta.servlet.http.HttpServletResponse;
@@ -34,10 +34,10 @@ public class GlobalExceptionHandler {
      * Business 오류 발생에 대한 핸들러
      */
     @ExceptionHandler(GlobalException.class)
-    public CommonRes<CommonEmptyRes> handleGlobalException(GlobalException e) {
+    public ApiResponse<CommonEmptyRes> handleGlobalException(GlobalException e) {
         response.setStatus(e.getResponseCode().getHttpStatus().value()); // HttpStatus 설정
 
-        return CommonRes.error(e.getResponseCode()); // 공통 응답 양식 반환
+        return ApiResponse.error(e.getResponseCode()); // 공통 응답 양식 반환
     }
 
     /**
@@ -52,23 +52,23 @@ public class GlobalExceptionHandler {
         MissingPathVariableException.class,
         MissingServletRequestParameterException.class
     })
-    public CommonRes<CommonEmptyRes> handleGlobalException(Exception e) {
+    public ApiResponse<CommonEmptyRes> handleGlobalException(Exception e) {
         response.setStatus(ResponseCode.INVALID_INPUT.getHttpStatus().value()); // HttpStatus 설정
 
-        return CommonRes.error(ResponseCode.INVALID_INPUT); // 공통 응답 양식 반환
+        return ApiResponse.error(ResponseCode.INVALID_INPUT); // 공통 응답 양식 반환
     }
 
     /**
      * Validation 라이브러리로 RequestBody 입력 파라미터 검증 오류 발생에 대한 핸들러
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public CommonRes<List<InvalidInputRes>> handlerValidationException(MethodArgumentNotValidException e) {
+    public ApiResponse<List<InvalidInputRes>> handlerValidationException(MethodArgumentNotValidException e) {
         response.setStatus(ResponseCode.INVALID_INPUT.getHttpStatus().value()); // HttpStatus 설정
 
         // 잘못된 입력 에러들을 DTO 변환
         List<InvalidInputRes> invalidInputResList = changeFieldErrorToDto(e);
 
-        return CommonRes.error(ResponseCode.INVALID_INPUT, invalidInputResList); // 공통 응답 양식 반환
+        return ApiResponse.error(ResponseCode.INVALID_INPUT, invalidInputResList); // 공통 응답 양식 반환
     }
 
     private List<InvalidInputRes> changeFieldErrorToDto(MethodArgumentNotValidException e) {
@@ -83,10 +83,10 @@ public class GlobalExceptionHandler {
      * 예상치 못한 에러 발생에 대한 핸들러
      */
     @ExceptionHandler({Exception.class, RuntimeException.class})
-    public CommonRes<CommonEmptyRes> handleException(Exception e) {
+    public ApiResponse<CommonEmptyRes> handleException(Exception e) {
         log.error("예상치 못한 에러 발생", e);
         response.setStatus(ResponseCode.SYSTEM_ERROR.getHttpStatus().value()); // HttpStatus 설정
 
-        return CommonRes.error(ResponseCode.SYSTEM_ERROR); // 공통 응답 양식 반환
+        return ApiResponse.error(ResponseCode.SYSTEM_ERROR); // 공통 응답 양식 반환
     }
 }

--- a/src/main/java/ex/sample/global/exception/InvalidInputMapper.java
+++ b/src/main/java/ex/sample/global/exception/InvalidInputMapper.java
@@ -1,6 +1,6 @@
 package ex.sample.global.exception;
 
-import ex.sample.global.response.InvalidInputRes;
+import ex.sample.global.response.InvalidInputResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants.ComponentModel;
@@ -11,5 +11,5 @@ public interface InvalidInputMapper {
 
     // FieldError 의 defaultMessage -> message 이름 변경
     @Mapping(source = "defaultMessage", target = "message")
-    InvalidInputRes toInvalidInputResponseDto(FieldError fieldError);
+    InvalidInputResponse toInvalidInputResponseDto(FieldError fieldError);
 }

--- a/src/main/java/ex/sample/global/response/ApiResponse.java
+++ b/src/main/java/ex/sample/global/response/ApiResponse.java
@@ -2,7 +2,7 @@ package ex.sample.global.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record CommonRes<T>(
+public record ApiResponse<T>(
     @Schema(description = "응답 코드", example = "0")
     String code, // 커스텀 응답 코드
 
@@ -16,28 +16,28 @@ public record CommonRes<T>(
     /**
      * data 필드에 값을 넣을 때 사용하는 메서드 - data 필드가 필요 없는 경우
      */
-    public static CommonRes<CommonEmptyRes> success() {
-        return new CommonRes<>(ResponseCode.SUCCESS.getCode(), ResponseCode.SUCCESS.getMessage(), new CommonEmptyRes());
+    public static ApiResponse<CommonEmptyRes> success() {
+        return new ApiResponse<>(ResponseCode.SUCCESS.getCode(), ResponseCode.SUCCESS.getMessage(), new CommonEmptyRes());
     }
 
     /**
      * data 필드에 값을 넣을 때 사용하는 메서드 - data 필드가 필요한 경우
      */
-    public static <T> CommonRes<T> success(T data) {
-        return new CommonRes<>(ResponseCode.SUCCESS.getCode(), ResponseCode.SUCCESS.getMessage(), data);
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(ResponseCode.SUCCESS.getCode(), ResponseCode.SUCCESS.getMessage(), data);
     }
 
     /**
      * 에러 발생 시 특정 에러에 맞는 응답하는 메서드 - data 필드가 필요 없는 경우
      */
-    public static CommonRes<CommonEmptyRes> error(ResponseCode responseCode) {
-        return new CommonRes<>(responseCode.getCode(), responseCode.getMessage(), new CommonEmptyRes());
+    public static ApiResponse<CommonEmptyRes> error(ResponseCode responseCode) {
+        return new ApiResponse<>(responseCode.getCode(), responseCode.getMessage(), new CommonEmptyRes());
     }
 
     /**
      * 에러 발생 시 특정 에러에 맞는 응답하는 메서드 - data 필드가 필요한 경우
      */
-    public static <T> CommonRes<T> error(ResponseCode responseCode, T data) {
-        return new CommonRes<>(responseCode.getCode(), responseCode.getMessage(), data);
+    public static <T> ApiResponse<T> error(ResponseCode responseCode, T data) {
+        return new ApiResponse<>(responseCode.getCode(), responseCode.getMessage(), data);
     }
 }

--- a/src/main/java/ex/sample/global/response/ApiResponse.java
+++ b/src/main/java/ex/sample/global/response/ApiResponse.java
@@ -16,8 +16,8 @@ public record ApiResponse<T>(
     /**
      * data 필드에 값을 넣을 때 사용하는 메서드 - data 필드가 필요 없는 경우
      */
-    public static ApiResponse<CommonEmptyRes> success() {
-        return new ApiResponse<>(ResponseCode.SUCCESS.getCode(), ResponseCode.SUCCESS.getMessage(), new CommonEmptyRes());
+    public static ApiResponse<EmptyResponse> success() {
+        return new ApiResponse<>(ResponseCode.SUCCESS.getCode(), ResponseCode.SUCCESS.getMessage(), new EmptyResponse());
     }
 
     /**
@@ -30,8 +30,8 @@ public record ApiResponse<T>(
     /**
      * 에러 발생 시 특정 에러에 맞는 응답하는 메서드 - data 필드가 필요 없는 경우
      */
-    public static ApiResponse<CommonEmptyRes> error(ResponseCode responseCode) {
-        return new ApiResponse<>(responseCode.getCode(), responseCode.getMessage(), new CommonEmptyRes());
+    public static ApiResponse<EmptyResponse> error(ResponseCode responseCode) {
+        return new ApiResponse<>(responseCode.getCode(), responseCode.getMessage(), new EmptyResponse());
     }
 
     /**

--- a/src/main/java/ex/sample/global/response/EmptyResponse.java
+++ b/src/main/java/ex/sample/global/response/EmptyResponse.java
@@ -3,6 +3,6 @@ package ex.sample.global.response;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties // 아무 필드가 없을 시 직렬화를 위한 어노테이션
-public record CommonEmptyRes() {
+public record EmptyResponse() {
 
 }

--- a/src/main/java/ex/sample/global/response/InvalidInputResponse.java
+++ b/src/main/java/ex/sample/global/response/InvalidInputResponse.java
@@ -1,6 +1,6 @@
 package ex.sample.global.response;
 
-public record InvalidInputRes(
+public record InvalidInputResponse(
     String field,
     String message
 ) {

--- a/src/main/java/ex/sample/global/response/PageResponse.java
+++ b/src/main/java/ex/sample/global/response/PageResponse.java
@@ -6,13 +6,13 @@ import org.springframework.data.domain.Page;
 /**
  * 공통 페이지 응답 객체
  */
-public record CommonPageRes<T>(
+public record PageResponse<T>(
     List<T> content,
     PageMeta meta
 ) {
 
-    public static <T> CommonPageRes<T> from(Page<T> page) {
-        return new CommonPageRes<>(page.getContent(), PageMeta.from(page));
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(page.getContent(), PageMeta.from(page));
     }
 
     public record PageMeta(

--- a/src/main/java/ex/sample/global/security/filter/ExceptionFilter.java
+++ b/src/main/java/ex/sample/global/security/filter/ExceptionFilter.java
@@ -2,7 +2,7 @@ package ex.sample.global.security.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import ex.sample.global.exception.GlobalException;
-import ex.sample.global.response.CommonRes;
+import ex.sample.global.response.ApiResponse;
 import ex.sample.global.response.ResponseCode;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -41,7 +41,7 @@ public class ExceptionFilter extends OncePerRequestFilter {
         response.setCharacterEncoding(StandardCharsets.UTF_8.name()); // charset : UTF8
 
         try {
-            String responseJson = objectMapper.writeValueAsString(CommonRes.error(responseCode));
+            String responseJson = objectMapper.writeValueAsString(ApiResponse.error(responseCode));
             response.getWriter().write(responseJson);
         } catch (IOException e) {
             log.error("예외 필터 직렬화 오류", e);

--- a/src/main/java/ex/sample/global/security/handler/LoginSuccessHandler.java
+++ b/src/main/java/ex/sample/global/security/handler/LoginSuccessHandler.java
@@ -2,7 +2,7 @@ package ex.sample.global.security.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import ex.sample.global.inmemory.InMemoryStore;
-import ex.sample.global.response.CommonRes;
+import ex.sample.global.response.ApiResponse;
 import ex.sample.global.security.jwt.JwtBearerUtils;
 import ex.sample.global.security.jwt.JwtConfig;
 import ex.sample.global.security.jwt.JwtTokenFactory;
@@ -40,7 +40,7 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE); // JSON 설정
         response.setCharacterEncoding(StandardCharsets.UTF_8.name()); // UTF8 설정하여 한글 표시
 
-        String result = objectMapper.writeValueAsString(CommonRes.success()); // JSON to String 변환
+        String result = objectMapper.writeValueAsString(ApiResponse.success()); // JSON to String 변환
         response.getWriter().write(result);
     }
 

--- a/src/main/java/ex/sample/global/security/handler/RefreshSuccessHandler.java
+++ b/src/main/java/ex/sample/global/security/handler/RefreshSuccessHandler.java
@@ -1,7 +1,7 @@
 package ex.sample.global.security.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import ex.sample.global.response.CommonRes;
+import ex.sample.global.response.ApiResponse;
 import ex.sample.global.security.jwt.JwtBearerUtils;
 import ex.sample.global.security.jwt.JwtConfig;
 import ex.sample.global.security.jwt.JwtTokenFactory;
@@ -29,7 +29,7 @@ public class RefreshSuccessHandler {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE); // JSON 설정
         response.setCharacterEncoding(StandardCharsets.UTF_8.name()); // UTF8 설정하여 한글 표시
 
-        String result = objectMapper.writeValueAsString(CommonRes.success()); // JSON to String 변환
+        String result = objectMapper.writeValueAsString(ApiResponse.success()); // JSON to String 변환
         response.getWriter().write(result);
     }
 


### PR DESCRIPTION
## 개요

- 응답 객체명을 보다 직관적이고 보편적으로 변경

## 작업사항

- CommonRes -> ApiResponse
- CommonEmptyRes -> EmptyResponse
- CommonPageRes -> PageResponse
- 그 외 -Req, -Res로 끝나는 DTO 접미사를 -Request, -Response로 변경 

## 세부사항

- 

## 관련 이슈

- 
