### PR TITLE
refactor: infra 디렉토리로 인메모리 디렉토리 이동

### DIFF
--- a/src/main/java/ex/sample/global/config/DatasourceConfig.java
+++ b/src/main/java/ex/sample/global/config/DatasourceConfig.java
@@ -1,4 +1,4 @@
-package ex.sample.global.datasource;
+package ex.sample.global.config;
 
 import com.zaxxer.hikari.HikariDataSource;
 import javax.sql.DataSource;

--- a/src/main/java/ex/sample/global/config/PropertyConfig.java
+++ b/src/main/java/ex/sample/global/config/PropertyConfig.java
@@ -1,4 +1,4 @@
-package ex.sample.global.property;
+package ex.sample.global.config;
 
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/ex/sample/global/config/SwaggerConfig.java
+++ b/src/main/java/ex/sample/global/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package ex.sample.global.swagger;
+package ex.sample.global.config;
 
 import ex.sample.global.security.jwt.JwtBearerUtils;
 import ex.sample.global.security.jwt.JwtConfig;

--- a/src/main/java/ex/sample/global/security/WebSecurityConfig.java
+++ b/src/main/java/ex/sample/global/security/WebSecurityConfig.java
@@ -1,7 +1,6 @@
 package ex.sample.global.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import ex.sample.global.inmemory.InMemoryStore;
 import ex.sample.global.security.filter.AuthFilter;
 import ex.sample.global.security.filter.ExceptionFilter;
 import ex.sample.global.security.filter.LoginFilter;
@@ -12,6 +11,7 @@ import ex.sample.global.security.jwt.JwtConfig;
 import ex.sample.global.security.provider.AccessTokenAuthenticationProvider;
 import ex.sample.global.security.provider.RefreshTokenAuthenticationProvider;
 import ex.sample.global.security.provider.UsernamePasswordAuthenticationProvider;
+import ex.sample.infra.inmemory.InMemoryStore;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;

--- a/src/main/java/ex/sample/global/security/filter/LogoutFilter.java
+++ b/src/main/java/ex/sample/global/security/filter/LogoutFilter.java
@@ -1,7 +1,7 @@
 package ex.sample.global.security.filter;
 
-import ex.sample.global.inmemory.InMemoryStore;
 import ex.sample.global.security.WebSecurityConfig;
+import ex.sample.infra.inmemory.InMemoryStore;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/ex/sample/global/security/handler/LoginSuccessHandler.java
+++ b/src/main/java/ex/sample/global/security/handler/LoginSuccessHandler.java
@@ -1,11 +1,11 @@
 package ex.sample.global.security.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import ex.sample.global.inmemory.InMemoryStore;
 import ex.sample.global.response.ApiResponse;
 import ex.sample.global.security.jwt.JwtBearerUtils;
 import ex.sample.global.security.jwt.JwtConfig;
 import ex.sample.global.security.jwt.JwtTokenFactory;
+import ex.sample.infra.inmemory.InMemoryStore;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;

--- a/src/main/java/ex/sample/global/security/provider/AccessTokenAuthenticationProvider.java
+++ b/src/main/java/ex/sample/global/security/provider/AccessTokenAuthenticationProvider.java
@@ -1,13 +1,13 @@
 package ex.sample.global.security.provider;
 
 import ex.sample.global.exception.GlobalException;
-import ex.sample.global.inmemory.InMemoryStore;
 import ex.sample.global.response.ResponseCode;
 import ex.sample.global.security.authentication.AccessTokenAuthentication;
 import ex.sample.global.security.jwt.JwtBearerUtils;
 import ex.sample.global.security.jwt.JwtClaimsExtractor;
 import ex.sample.global.security.jwt.JwtStatus;
 import ex.sample.global.security.jwt.JwtValidator;
+import ex.sample.infra.inmemory.InMemoryStore;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/ex/sample/global/security/provider/RefreshTokenAuthenticationProvider.java
+++ b/src/main/java/ex/sample/global/security/provider/RefreshTokenAuthenticationProvider.java
@@ -1,13 +1,13 @@
 package ex.sample.global.security.provider;
 
 import ex.sample.global.exception.GlobalException;
-import ex.sample.global.inmemory.InMemoryStore;
 import ex.sample.global.response.ResponseCode;
 import ex.sample.global.security.authentication.RefreshTokenAuthentication;
 import ex.sample.global.security.jwt.JwtBearerUtils;
 import ex.sample.global.security.jwt.JwtClaimsExtractor;
 import ex.sample.global.security.jwt.JwtStatus;
 import ex.sample.global.security.jwt.JwtValidator;
+import ex.sample.infra.inmemory.InMemoryStore;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/ex/sample/infra/inmemory/CacheConfig.java
+++ b/src/main/java/ex/sample/infra/inmemory/CacheConfig.java
@@ -1,4 +1,4 @@
-package ex.sample.global.inmemory;
+package ex.sample.infra.inmemory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;

--- a/src/main/java/ex/sample/infra/inmemory/InMemoryStore.java
+++ b/src/main/java/ex/sample/infra/inmemory/InMemoryStore.java
@@ -1,10 +1,10 @@
-package ex.sample.global.inmemory;
+package ex.sample.infra.inmemory;
 
 import java.time.Duration;
 import java.util.Optional;
 
 public interface InMemoryStore {
-    
+
     <T> void put(String key, T value);
 
     <T> void put(String key, T value, Duration ttl);

--- a/src/main/java/ex/sample/infra/inmemory/redis/RedisCacheConfig.java
+++ b/src/main/java/ex/sample/infra/inmemory/redis/RedisCacheConfig.java
@@ -1,4 +1,4 @@
-package ex.sample.infra.inmemory;
+package ex.sample.infra.inmemory.redis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
@@ -14,13 +14,13 @@ import org.springframework.data.redis.serializer.RedisSerializer;
 
 @Configuration
 @RequiredArgsConstructor
-public class CacheConfig {
+public class RedisCacheConfig {
 
     private final ObjectMapper objectMapper;
     private final RedisConnectionFactory redisConnectionFactory;
 
     @Bean
-    public RedisCacheManager cacheManager() {
+    public RedisCacheManager redisCacheManager() {
 
         GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
 

--- a/src/main/java/ex/sample/infra/inmemory/redis/RedisCacheConfig.java
+++ b/src/main/java/ex/sample/infra/inmemory/redis/RedisCacheConfig.java
@@ -2,7 +2,6 @@ package ex.sample.infra.inmemory.redis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
@@ -13,14 +12,10 @@ import org.springframework.data.redis.serializer.RedisSerializationContext.Seria
 import org.springframework.data.redis.serializer.RedisSerializer;
 
 @Configuration
-@RequiredArgsConstructor
 public class RedisCacheConfig {
 
-    private final ObjectMapper objectMapper;
-    private final RedisConnectionFactory redisConnectionFactory;
-
     @Bean
-    public RedisCacheManager redisCacheManager() {
+    public RedisCacheManager redisCacheManager(ObjectMapper objectMapper, RedisConnectionFactory redisConnectionFactory) {
 
         GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
 

--- a/src/main/java/ex/sample/infra/inmemory/redis/RedisConfig.java
+++ b/src/main/java/ex/sample/infra/inmemory/redis/RedisConfig.java
@@ -34,10 +34,10 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Object> redisTemplate() {
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
 
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
 
         // Serializer 설정
         redisTemplate.setKeySerializer(RedisSerializer.string());
@@ -51,7 +51,7 @@ public class RedisConfig {
     }
 
     @Bean
-    public StringRedisTemplate stringRedisTemplate() {
-        return new StringRedisTemplate(redisConnectionFactory());
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        return new StringRedisTemplate(redisConnectionFactory);
     }
 }

--- a/src/main/java/ex/sample/infra/inmemory/redis/RedisConfig.java
+++ b/src/main/java/ex/sample/infra/inmemory/redis/RedisConfig.java
@@ -1,4 +1,4 @@
-package ex.sample.global.inmemory.redis;
+package ex.sample.infra.inmemory.redis;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/ex/sample/infra/inmemory/redis/RedisInMemoryStore.java
+++ b/src/main/java/ex/sample/infra/inmemory/redis/RedisInMemoryStore.java
@@ -1,10 +1,10 @@
-package ex.sample.global.inmemory.redis;
+package ex.sample.infra.inmemory.redis;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import ex.sample.global.exception.GlobalException;
-import ex.sample.global.inmemory.InMemoryStore;
 import ex.sample.global.response.ResponseCode;
+import ex.sample.infra.inmemory.InMemoryStore;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;


### PR DESCRIPTION
## 개요

- 특정 인프라 종속적인 inmemory 디렉토리를 infra 디렉토리 하위로 이동

## 작업사항

- global/inmemory -> infra/inmemory로 이동
- 단일 Config 클래스밖에 없던 global 내의 디렉토리들을 global/config 디렉토리 하위로 응집

## 세부사항

- 

## 관련 이슈

- 
