### PR TITLE
feat: 공통응답으로 감싸는 어드바이스 추가 

### DIFF
--- a/src/main/java/ex/sample/domain/sample/controller/SampleController.java
+++ b/src/main/java/ex/sample/domain/sample/controller/SampleController.java
@@ -5,7 +5,6 @@ import ex.sample.domain.sample.dto.response.CreateSampleResponse;
 import ex.sample.domain.sample.dto.response.GetSampleResponse;
 import ex.sample.domain.sample.service.SampleCommandService;
 import ex.sample.domain.sample.service.SampleQueryService;
-import ex.sample.global.response.ApiResponse;
 import ex.sample.global.response.PageResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,28 +32,25 @@ public class SampleController {
      * 샘플 단건 조회
      */
     @GetMapping("/{id}")
-    public ApiResponse<GetSampleResponse> getSample(@PathVariable("id") Long id) {
-        GetSampleResponse response = sampleQueryService.getSample(id);
-        return ApiResponse.success(response);
+    public GetSampleResponse getSample(@PathVariable("id") Long id) {
+        return sampleQueryService.getSample(id);
     }
 
     /**
      * 샘플 리스트 조회
      */
     @GetMapping
-    public ApiResponse<PageResponse<GetSampleResponse>> getSample(
+    public PageResponse<GetSampleResponse> getSample(
         @PageableDefault(size = 20, sort = "createdAt", direction = Direction.DESC) Pageable pageable
     ) {
-        PageResponse<GetSampleResponse> response = sampleQueryService.getSampleList(pageable);
-        return ApiResponse.success(response);
+        return sampleQueryService.getSampleList(pageable);
     }
 
     /**
      * 샘플 생성
      */
     @PostMapping
-    public ApiResponse<CreateSampleResponse> createSample(@Validated @RequestBody CreateSampleRequest request) {
-        CreateSampleResponse response = sampleCommandService.createSample(request);
-        return ApiResponse.success(response);
+    public CreateSampleResponse createSample(@Validated @RequestBody CreateSampleRequest request) {
+        return sampleCommandService.createSample(request);
     }
 }

--- a/src/main/java/ex/sample/domain/user/controller/UserAuthController.java
+++ b/src/main/java/ex/sample/domain/user/controller/UserAuthController.java
@@ -3,8 +3,6 @@ package ex.sample.domain.user.controller;
 import ex.sample.domain.user.dto.request.UserSignupRequest;
 import ex.sample.domain.user.dto.request.UserWithdrawalRequest;
 import ex.sample.domain.user.service.UserAuthService;
-import ex.sample.global.response.ApiResponse;
-import ex.sample.global.response.EmptyResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,19 +23,17 @@ public class UserAuthController {
     private final UserAuthService userAuthService;
 
     @PostMapping("/signup")
-    public ApiResponse<EmptyResponse> signup(
+    public void signup(
         @Valid @RequestBody UserSignupRequest request
     ) {
-        EmptyResponse response = userAuthService.signup(request);
-        return ApiResponse.success(response);
+        userAuthService.signup(request);
     }
 
     @DeleteMapping
-    public ApiResponse<EmptyResponse> delete(
+    public void delete(
         @AuthenticationPrincipal UserDetails userDetails,
         @Valid @RequestBody UserWithdrawalRequest request
     ) {
-        EmptyResponse response = userAuthService.deleteUser(userDetails, request);
-        return ApiResponse.success(response);
+        userAuthService.deleteUser(userDetails, request);
     }
 }

--- a/src/main/java/ex/sample/global/response/ApiResponseAdvice.java
+++ b/src/main/java/ex/sample/global/response/ApiResponseAdvice.java
@@ -1,0 +1,41 @@
+package ex.sample.global.response;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+/**
+ * 공통응답으로 감싸주는 어드바이스
+ */
+@RestControllerAdvice
+public class ApiResponseAdvice implements ResponseBodyAdvice<Object> {
+
+    /**
+     * 실패 응답 (GlobalExceptionHandler error 처리가 된 응답)은 이미 ApiResponse 감싸져서 해당되지 않음
+     */
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return !returnType.getParameterType().equals(ApiResponse.class);
+    }
+
+    @Override
+    public Object beforeBodyWrite(
+        Object body,
+        MethodParameter returnType,
+        MediaType selectedContentType,
+        Class<? extends HttpMessageConverter<?>> selectedConverterType,
+        ServerHttpRequest request,
+        ServerHttpResponse response
+    ) {
+        // 빈 응답은 기본 응답으로 처리
+        if (body == null || returnType.getParameterType().equals(Void.TYPE)) {
+            return ApiResponse.success();
+        }
+
+        return ApiResponse.success(body); // 성공 응답에 공통 응답 처리
+    }
+}


### PR DESCRIPTION
## 개요

- 기존의 코드는 매번 공통응답 클래스로 감싸주어야 했다. 이러한 보일러 플레이트를 제거하고자 응답 DTO를 자동으로 공통응답으로 감싸주는 어드바이스를 추가하였다.

## 작업사항

- `ApiResponseAdvice` 추가
    - 컨트롤러의 보일러 플레이트를 제거하는데 의의를 두고자, 이미 `ApiResponse`로 응답되는 에외처리 응답의 경우는 그대로 응답하기로 함 
- 기존의 컨트롤러에서 작성된 보일러 플레이트 제거

## 세부사항

- `ApiResponseAdvice` 추가 
    ```java
    import org.springframework.core.MethodParameter;
    import org.springframework.http.MediaType;
    import org.springframework.http.converter.HttpMessageConverter;
    import org.springframework.http.server.ServerHttpRequest;
    import org.springframework.http.server.ServerHttpResponse;
    import org.springframework.web.bind.annotation.RestControllerAdvice;
    import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
    
    /**
     * 공통응답으로 감싸주는 어드바이스
     */
    @RestControllerAdvice
    public class ApiResponseAdvice implements ResponseBodyAdvice<Object> {
    
        /**
         * 실패 응답 (GlobalExceptionHandler error 처리가 된 응답)은 이미 ApiResponse 감싸져서 해당되지 않음
         */
        @Override
        public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
            return !returnType.getParameterType().equals(ApiResponse.class);
        }
    
        @Override
        public Object beforeBodyWrite(
            Object body,
            MethodParameter returnType,
            MediaType selectedContentType,
            Class<? extends HttpMessageConverter<?>> selectedConverterType,
            ServerHttpRequest request,
            ServerHttpResponse response
        ) {
            // 빈 응답은 기본 응답으로 처리
            if (body == null || returnType.getParameterType().equals(Void.TYPE)) {
                return ApiResponse.success();
            }
    
            return ApiResponse.success(body); // 성공 응답에 공통 응답 처리
        }
    }
    ```
- 기존의 컨트롤러에서 공통 응답 제거 
    ```java
        // 기존 컨트롤러 
    
        /**
         * 샘플 단건 조회
         */
        @GetMapping("/{id}")
        public ApiResponse<GetSampleResponse> getSample(@PathVariable("id") Long id) {
            return ApiResponse.success(sampleQueryService.getSample(id));
        }
    
        @PostMapping("/signup")
        public ApiResponse<EmptyResponse> signup(
            @Valid @RequestBody UserSignupRequest request
        ) {
            userAuthService.signup(request);
            return ApiResponse.success();
        }
    
        // 변경 컨트롤러 
    
        /**
         * 샘플 단건 조회
         */
        @GetMapping("/{id}")
        public GetSampleResponse getSample(@PathVariable("id") Long id) {
            return sampleQueryService.getSample(id);
        }
    
        @PostMapping("/signup")
        public void signup(
            @Valid @RequestBody UserSignupRequest request
        ) {
            userAuthService.signup(request);
        }
    ```

## 관련 이슈

- 
