### PR TITLE
Build: 자바/스프링 버전 업 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'jacoco'
-    id 'org.springframework.boot' version '3.5.4'
+    id 'org.springframework.boot' version '4.0.0'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 
@@ -36,10 +36,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     // QueryDSL
-    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
-    annotationProcessor "com.querydsl:querydsl-apt:5.1.0:jakarta"
-    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    implementation "io.github.openfeign.querydsl:querydsl-jpa-spring:7.1"
+    annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:7.1:jpa"
 
     // security
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -65,12 +63,12 @@ dependencies {
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
 
     // swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.0'
 
     // JWT
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
-    implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
-    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.13.0'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.13.0'
 
     // mail
     implementation 'org.springframework.boot:spring-boot-starter-mail'
@@ -83,16 +81,32 @@ dependencies {
 
     // Spring
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+
     testImplementation 'org.springframework.security:spring-security-test'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-redis-test'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-mail-test'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-thymeleaf-test'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
+
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // test database
     testRuntimeOnly 'com.h2database:h2'
 
     // JWT
-    testCompileOnly 'io.jsonwebtoken:jjwt-api:0.12.6'
-    testCompileOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
-    testCompileOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    testCompileOnly 'io.jsonwebtoken:jjwt-api:0.13.0'
+    testCompileOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
+    testCompileOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
 }
 
 clean {
@@ -108,7 +122,6 @@ tasks.named('test') {
 jacocoTestReport {
     reports {
         // 리포트 타입마다 리포트 저장 경로를 설정할 수 있습니다.
-        html.destination file("jacoco/report")
     }
 
     // QueryDsl Q class 제외

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/ex/sample/global/config/ObjectMapperConfig.java
+++ b/src/main/java/ex/sample/global/config/ObjectMapperConfig.java
@@ -22,7 +22,10 @@ public class ObjectMapperConfig {
         mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
         // null 필드 제외 (선택 사항)
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        mapper.setDefaultPropertyInclusion(JsonInclude.Value.construct(
+            JsonInclude.Include.NON_NULL, // 직렬화 시 포함할 기준
+            JsonInclude.Include.NON_NULL  // 역직렬화 시 포함할 기준 (보통 직렬화와 동일하게 설정)
+        ));
 
         // 알 수 없는 필드가 있어도 예외 발생하지 않음
         mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);

--- a/src/main/java/ex/sample/global/security/authentication/JwtAuthentication.java
+++ b/src/main/java/ex/sample/global/security/authentication/JwtAuthentication.java
@@ -17,7 +17,7 @@ public abstract class JwtAuthentication extends AbstractAuthenticationToken {
      * 인증 전
      */
     protected JwtAuthentication(String token) {
-        super(null);
+        super((Collection<? extends GrantedAuthority>) null);
         this.token = token;
         this.principal = null;
         setAuthenticated(false);

--- a/src/main/java/ex/sample/global/security/config/WebSecurityConfig.java
+++ b/src/main/java/ex/sample/global/security/config/WebSecurityConfig.java
@@ -7,7 +7,7 @@ import ex.sample.global.security.filter.LogoutFilter;
 import ex.sample.global.security.filter.RefreshFilter;
 import ex.sample.global.security.jwt.JwtConfig;
 import java.util.List;
-import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.boot.security.autoconfigure.web.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -74,6 +74,7 @@ public class WebSecurityConfig {
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/v3/api-docs.yaml").permitAll()
                 // Sample 도메인
                 .requestMatchers("/samples/**").permitAll()
+                .requestMatchers("/users/**").permitAll()
                 // 인증
                 .requestMatchers(HttpMethod.POST, UrlConstant.SIGNUP_URL, UrlConstant.REFRESH_URL).permitAll()
                 // 그 외

--- a/src/main/java/ex/sample/infra/inmemory/redis/RedisCacheConfig.java
+++ b/src/main/java/ex/sample/infra/inmemory/redis/RedisCacheConfig.java
@@ -1,15 +1,14 @@
 package ex.sample.infra.inmemory.redis;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
 import org.springframework.data.redis.serializer.RedisSerializer;
+import tools.jackson.databind.ObjectMapper;
 
 @Configuration
 public class RedisCacheConfig {
@@ -17,11 +16,9 @@ public class RedisCacheConfig {
     @Bean
     public RedisCacheManager redisCacheManager(ObjectMapper objectMapper, RedisConnectionFactory redisConnectionFactory) {
 
-        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
-
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig() // 기본 설정
             .serializeKeysWith(SerializationPair.fromSerializer(RedisSerializer.string())) // 키는 문자열
-            .serializeValuesWith(SerializationPair.fromSerializer(serializer)) // 직렬화
+            .serializeValuesWith(SerializationPair.fromSerializer(RedisSerializer.json())) // 직렬화
             .entryTtl(Duration.ofSeconds(5L)) // 기본 캐싱 TTL 설정
             .disableCachingNullValues(); // null 캐싱 불가
 


### PR DESCRIPTION
## 개요

- 자바 25, 스프링 부트 4.0.0 대응 버전 업 

## 작업사항

- 자바 17 -> 25
- 스프링 부트 3.5.4 -> 4.0.0
- Gradle 8.8 -> 9.2.1
- QueryDSL 패키지를 OpenFeign으로 변경 
- 스프링 테스트 모듈 의존
- 기타 라이브러리 버전 최신화 
- 기타 `@Deprecated` 코드 최신화 

## 세부사항

- 

## 관련 이슈

- 